### PR TITLE
Feat: Added Support to Re Watch Episodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ docker compose up
 Navigating to the home page http://[host]:[port] in your browser will display the webhook URL you can enter in Plex > Settings > Webhooks. It should be http://[host]:[port]/webhook/plex You may need to restart your Plex media server for these changes to take effect.<br><br>
 Plex-TVTime will mark episodes as watched on your TVTime profile once you have watched them passed the configured 'Video played threshold' in Plex (You can adjust this % in Plex Settings > Library). Plex <strong>does not</strong> send webhooks when episodes are manaully marked as watched.<br><br>
 Watching an episode for a show that has not been added to you TVTime profile will automatically add the show. If this behavior is undesired, you can make use of the Excluded/Included configuration parameters below to restrict which shows are sent to TVTime.<br><br>
-Watching an episode for a show you have already marked as watched in TVTime has no effect, the episode is not marked as 'rewatched' in TVTime, nor is the time you first marked the episode as watched updated.<br><br>
+Watching an episode for a show you have already marked as watched in TVTime has no effect, the episode is not marked as 'rewatched' in TVTime(unless MARK_REWATCH_EPISODES is enabled), nor is the time you first marked the episode as watched updated.<br><br>
 As of v1.1.0 Plex-TVTime supports linking multiple TVTime accounts through advanced configuration. <a href="https://github.com/Zggis/plex-tvtime#linking-multiple-tvtime-accounts-only-available-in-v110">See details below.</a>
 
 ### Basic Configuration
@@ -43,6 +43,7 @@ Container Variable | Default Value | Description
 --- | --- | ---
 TRACK_MOVIES | false | Set to true to track movies in TVTime.
 MARK_PREVIOUS_EPISODES | false | Set to true to mark all previous episodes of a TV show as watched when you watch a episode.
+MARK_REWATCH_EPISODES | false | Set to true to automatically mark an episode as rewatched and increase the counter in TVTime.
 PLEX_SHOWS_EXCLUDE | Undefined | A comma separated list of TV show titles that will not be sent to TVTime. TVShow title should be identicle to how it appears in your Plex library. If the title includes a comma in it replace it with %2C to avoid conflicting with the comma delimeters in the list.
 PLEX_SHOWS_INCLUDE | Undefined | Overridden and ignored if PLEX_SHOWS_EXCLUDE is set, otherwise only shows that appear in this list will be sent to TVTime.
 LOGGING_LEVEL | INFO | Set to TRACE or DEBUG for additional logging.

--- a/example-configs/application.yaml
+++ b/example-configs/application.yaml
@@ -22,6 +22,7 @@ account-config:
       
 track-movies: ${TRACK_MOVIES:false}
 mark-previous-episodes: ${MARK_PREVIOUS_EPISODES:false}
+mark-rewatch-episodes: ${MARK_REWATCH_EPISODES:false}
 logging:
   level:
     com:

--- a/src/main/java/com/zggis/plextvtime/service/TVTimeServiceImpl.java
+++ b/src/main/java/com/zggis/plextvtime/service/TVTimeServiceImpl.java
@@ -37,6 +37,9 @@ public class TVTimeServiceImpl implements TVTimeService {
   @Value("${mark-previous-episodes:false}")
   private boolean markPreviousEpisodes;
 
+  @Value("${mark-rewatch-episodes:false}")
+  private boolean markReWatchEpisodes;
+
   private final Map<String, Triplet<String, String, JSONObject>> userAuth = new HashMap<>();
 
   @Override
@@ -121,8 +124,9 @@ public class TVTimeServiceImpl implements TVTimeService {
       bodySpec =
           uriSpec.uri(
               "/sidecar?o=https://api2.tozelabs.com/v2/watched_episodes/episode/"
-                  + mediaId
-                  + "&is_rewatch=0");
+                      + mediaId
+                      + "&is_rewatch="
+                      + (markReWatchEpisodes ? "1" : "0"));
       requestHeadersSpec = bodySpec.bodyValue(userAuth.get(user).getValue2().toString());
       requestHeadersSpec
           .header(HttpHeaders.AUTHORIZATION, "Bearer " + userAuth.get(user).getValue0())

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,5 +16,6 @@ logfile:
   dir: /logs
 track-movies: ${TRACK_MOVIES:false}
 mark-previous-episodes: ${MARK_PREVIOUS_EPISODES:false}
+mark-rewatch-episodes: ${MARK_REWATCH_EPISODES:false}
 server:
   port: ${SERVER_PORT:8080}


### PR DESCRIPTION
Added Support to mark episodes as rewatched in TV Time, This still works the same and doesn't affect new watches in way as tested 

### Context on why This was needed: 
Currently The Plugin didn't support rewatches in tv time, and honestly i was happy to find something that works with jellyfin( huge thanks for that @Zggis ) 

but what i ended up noticing. was even though it doesn't change the initial watch time for the rewatched eps as expected. BUT it was overwriting my rewatch History! like on few eps i had like 6 rewatches after this plugin updates it resets the counter to 1 from x6!  Check the below video. 

https://github.com/user-attachments/assets/5dda9f44-8fb0-465c-a3f7-73cb1dc13b7d

After digging around the rewatch api, found that setting the is_rewatch to true for all videos didnt impact new videos(in anyway) and old videos were being processed correctly with the counter increasing properly 
[Video Working on Existing Ep]

https://github.com/user-attachments/assets/1ad1f72e-c542-429f-b61d-9a7297e2a72a


[Video Working on New Ep]

https://github.com/user-attachments/assets/5178009f-5ac3-447d-82ba-829369b0175b


