### PR TITLE
feat: Add Discord notifications for startup and login events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ out/
 .vscode/
 /drivers/
 /browsers/
+
+### Local Development ###
+docker-compose.dev.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
+# Build stage
+FROM gradle:8.5-jdk17 AS builder
+WORKDIR /app
+COPY build.gradle settings.gradle ./
+COPY gradle ./gradle
+COPY src ./src
+RUN gradle build -x test --no-daemon
+
+# Runtime stage
 FROM zenika/alpine-chrome:with-selenoid
 EXPOSE 8080
 USER root
 RUN apk add dpkg
 RUN apk add openjdk17
-COPY /build/libs/*.jar app.jar
+COPY --from=builder /app/build/libs/*.jar app.jar
 ENTRYPOINT ["java","-XX:+UseSerialGC","-Xss512k", "-Xms64m", "-Xmx128m", "-jar","-Dspring.profiles.active=docker","./app.jar"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,25 @@ You can run Plex-TVTime on Docker locally by using the following command. Replac
 $ docker run -e TVTIME_USER={Your TVTime username} -e TVTIME_PASSWORD={Your TVTime password} -e PLEX_USERS={Plex username(s) to link} -p 8080:8080 zggis/plex-tvtime:latest
 ```
 #### Docker Compose
-Example compose and env files can be found <a href="https://github.com/Zggis/plex-tvtime/tree/master/example-configs">here.</a>
+Example compose file can be found <a href="https://github.com/Zggis/plex-tvtime/tree/master/example-configs">here.</a>
+```yaml
+version: '3.9'
+services:
+  plex-tvtime:
+    image: zggis/plex-tvtime:latest
+    ports:
+      - '8080:8080'
+    environment:
+      - TVTIME_USER=your_tvtime_username
+      - TVTIME_PASSWORD=your_tvtime_password
+      - PLEX_USERS=plex_user1,plex_user2
+      - TRACK_MOVIES=true
+      - DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/your_webhook_url
+    volumes:
+      - ./logs:/logs
+      - ./config:/config
+    restart: unless-stopped
+```
 ```
 $ docker compose up
 ```
@@ -48,6 +66,9 @@ PLEX_SHOWS_EXCLUDE | Undefined     | A comma separated list of TV show titles th
 PLEX_SHOWS_INCLUDE | Undefined     | Overridden and ignored if PLEX_SHOWS_EXCLUDE is set, otherwise only shows that appear in this list will be sent to TVTime.
 LOGGING_LEVEL | INFO          | Set to TRACE or DEBUG for additional logging.
 SERVER_PORT | 8080          | Set to change the port the application will use within the docker container.
+DISCORD_WEBHOOK_URL | Undefined     | Discord webhook URL for notifications. Create one in Discord Server Settings > Integrations > Webhooks.
+DISCORD_HOST_URL | Undefined     | Your server's URL (e.g., http://192.168.1.100:8080) to display in Discord notifications.
+DISCORD_NOTIFY_ON_STARTUP | true          | Set to false to disable the startup notification to Discord.
 
 #### Optional Mappings
 Container Path | Description
@@ -68,6 +89,24 @@ If you are using the docker compose file, you will need to specify SPRING_CONFIG
 
 ### Jellyfin Support
 As of v2.4.0 Plex-TVTime supports Jellyfin integration for TV Shows. [See this page to configure it](https://github.com/Zggis/plex-tvtime/blob/master/jellyfin.md).
+
+### Discord Notifications
+As of v2.6.0 Plex-TVTime supports Discord notifications to keep you informed about the application status.
+
+#### Features
+- **Startup Notification**: Get notified when the application starts with the webhook URL ready to configure
+- **Login Notification**: Get notified when a TVTime user successfully logs in
+
+#### Setup
+1. Go to your Discord server → **Server Settings** → **Integrations** → **Webhooks**
+2. Click **New Webhook**, choose a channel, and copy the webhook URL
+3. Add the `DISCORD_WEBHOOK_URL` environment variable to your container
+
+#### Example Notification
+When the application starts, you'll receive a message like:
+> ✅ **Plex-TVTime** is now up and running!
+> 📡 Webhook endpoint ready at port `8080`
+> 🔗 Configure Plex webhook to: `http://192.168.1.100:8080/webhook/plex`
 
 ### Troubleshooting
 Please check the logs, as described above many webhook events are intentionally ignored depending on configuration. If you can't resolve on your own open an <a href="https://github.com/Zggis/plex-tvtime/issues/new">issue</a> and I will help. If you open an issue please set the LOGGING_LEVEL to TRACE and include the relevant logs in your issue, the app does not create its own logfile, so you can just copy them from the console logs.<br><br>

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ services:
       - PLEX_USERS=plex_user1,plex_user2
       - TRACK_MOVIES=true
       - DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/your_webhook_url
+      # Optional: Set the externally accessible base URL for accurate links in Discord notifications
+      - DISCORD_HOST_URL=http://your-public-host:8080
     volumes:
       - ./logs:/logs
       - ./config:/config

--- a/example-configs/docker-compose.yaml
+++ b/example-configs/docker-compose.yaml
@@ -1,12 +1,18 @@
-version: '3'
+version: '3.9'
 services:
   plex-tvtime:
     image: zggis/plex-tvtime:latest
-    env_file: 
-      - .env
     ports:
-      - 8080:8080
-    #Volume only needed for advanced configuration (multiple TVTime users)
+      - '8080:8080'
+    environment:
+      - TVTIME_USER=${TVTIME_USER}
+      - TVTIME_PASSWORD=${TVTIME_PASSWORD}
+      - PLEX_USERS=${PLEX_USERS}
+      - TRACK_MOVIES=${TRACK_MOVIES:-false}
+      - DISCORD_WEBHOOK_URL=${DISCORD_WEBHOOK_URL:-}
+      - DISCORD_NOTIFY_ON_STARTUP=${DISCORD_NOTIFY_ON_STARTUP:-true}
     volumes:
-      - "C:/location/of/yaml/:/config"
+      - ./logs:/logs
+      - ./config:/config
+    restart: unless-stopped
 

--- a/example-configs/docker-compose.yaml
+++ b/example-configs/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
       - PLEX_USERS=${PLEX_USERS}
       - TRACK_MOVIES=${TRACK_MOVIES:-false}
       - DISCORD_WEBHOOK_URL=${DISCORD_WEBHOOK_URL:-}
+      - DISCORD_HOST_URL=${DISCORD_HOST_URL:-}
       - DISCORD_NOTIFY_ON_STARTUP=${DISCORD_NOTIFY_ON_STARTUP:-true}
     volumes:
       - ./logs:/logs

--- a/src/main/java/com/zggis/plextvtime/service/DiscordNotificationService.java
+++ b/src/main/java/com/zggis/plextvtime/service/DiscordNotificationService.java
@@ -1,0 +1,95 @@
+package com.zggis.plextvtime.service;
+
+import com.zggis.plextvtime.util.ConsoleColor;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@Slf4j
+public class DiscordNotificationService {
+
+    @Value("${discord.webhook-url:#{null}}")
+    private String webhookUrl;
+
+    @Value("${discord.notify-on-startup:true}")
+    private boolean notifyOnStartup;
+
+    @Value("${discord.host-url:#{null}}")
+    private String hostUrl;
+
+    @Value("${server.port:8080}")
+    private String serverPort;
+
+    private WebClient webClient;
+
+    @PostConstruct
+    public void init() {
+        if (StringUtils.hasText(webhookUrl)) {
+            this.webClient = WebClient.builder()
+                    .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .build();
+            log.info("Discord notifications enabled");
+        } else {
+            log.debug("Discord webhook URL not configured, notifications disabled");
+        }
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onApplicationReady() {
+        if (notifyOnStartup && StringUtils.hasText(webhookUrl)) {
+            sendStartupNotification();
+        }
+    }
+
+    private void sendStartupNotification() {
+        String webhookEndpoint;
+        if (StringUtils.hasText(hostUrl)) {
+            webhookEndpoint = hostUrl + "/webhook/plex";
+        } else {
+            webhookEndpoint = "http://[host]:" + serverPort + "/webhook/plex";
+        }
+        String message = "✅ **Plex-TVTime** is now up and running!\n" +
+                "📡 Webhook endpoint ready at port `" + serverPort + "`\n" +
+                "🔗 Configure Plex webhook to: `" + webhookEndpoint + "`";
+        sendNotification(message);
+    }
+
+    public void sendNotification(String message) {
+        if (!StringUtils.hasText(webhookUrl)) {
+            log.debug("Discord webhook URL not configured, skipping notification");
+            return;
+        }
+
+        try {
+            JSONObject payload = new JSONObject();
+            payload.put("content", message);
+
+            webClient.post()
+                    .uri(webhookUrl)
+                    .bodyValue(payload.toString())
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .subscribe(
+                            response -> log.debug("Discord notification sent successfully"),
+                            error -> log.warn("{}Failed to send Discord notification: {}{}",
+                                    ConsoleColor.YELLOW.value,
+                                    error.getMessage(),
+                                    ConsoleColor.NONE.value)
+                    );
+        } catch (Exception e) {
+            log.warn("{}Failed to send Discord notification: {}{}",
+                    ConsoleColor.YELLOW.value,
+                    e.getMessage(),
+                    ConsoleColor.NONE.value);
+        }
+    }
+}

--- a/src/main/java/com/zggis/plextvtime/service/MediaManagerServiceImpl.java
+++ b/src/main/java/com/zggis/plextvtime/service/MediaManagerServiceImpl.java
@@ -27,6 +27,8 @@ public class MediaManagerServiceImpl implements MediaManagerService {
 
   @Autowired private TVTimeService tvTimeService;
 
+  @Autowired private DiscordNotificationService discordNotificationService;
+
   @Value("${track-movies:false}")
   private boolean trackMovies;
 
@@ -302,6 +304,7 @@ public class MediaManagerServiceImpl implements MediaManagerService {
             ConsoleColor.GREEN.value,
             user,
             ConsoleColor.NONE.value);
+        discordNotificationService.sendNotification("✅ **" + user + "** has been successfully logged in to TVTime!");
         return;
       } catch (TVTimeException e) {
         log.error(

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,5 +17,9 @@ logfile:
 track-movies: ${TRACK_MOVIES:false}
 mark-previous-episodes: ${MARK_PREVIOUS_EPISODES:false}
 mark-rewatch-episodes: ${MARK_REWATCH_EPISODES:false}
+discord:
+  webhook-url: ${DISCORD_WEBHOOK_URL:}
+  notify-on-startup: ${DISCORD_NOTIFY_ON_STARTUP:true}
+  host-url: ${DISCORD_HOST_URL:}
 server:
   port: ${SERVER_PORT:8080}


### PR DESCRIPTION
- Add DiscordNotificationService for sending webhook notifications
- Send notification when application starts with webhook URL info
- Send notification when TVTime user successfully logs in
- Add DISCORD_WEBHOOK_URL, DISCORD_HOST_URL, DISCORD_NOTIFY_ON_STARTUP env vars
- Update README with Discord notification documentation
- Update Dockerfile to support multi-stage builds
- Update example docker-compose.yaml with Discord configuration